### PR TITLE
解决参数优化过程中，内存泄露的问题

### DIFF
--- a/vnpy/app/cta_strategy/backtesting.py
+++ b/vnpy/app/cta_strategy/backtesting.py
@@ -538,7 +538,7 @@ class BacktestingEngine:
             return
 
         # Use multiprocessing pool for running backtesting with different setting
-        pool = multiprocessing.Pool(multiprocessing.cpu_count())
+        pool = multiprocessing.Pool(multiprocessing.cpu_count(), maxtasksperchild=1)
 
         results = []
         for setting in settings:


### PR DESCRIPTION
建议每次发起的PR内容尽可能精简，复杂的修改请拆分为多次PR，便于管理合并。

## 改进内容

1. 在策略中使用Talib的某些指标时，会发生内存泄漏问题
2. 修改pool的逻辑，增加maxtasksperchild，回收内存
优化前：
![image](https://user-images.githubusercontent.com/2801450/70040433-883c1b00-15f6-11ea-9ed6-33e4b6a5b4fa.png)
优化后：
![image](https://user-images.githubusercontent.com/2801450/70040446-8d00cf00-15f6-11ea-820c-8637a845734a.png)

## 相关的Issue号（如有）

Close #